### PR TITLE
Update holder number format and add links to holders

### DIFF
--- a/src/components/BurnedTokens.css
+++ b/src/components/BurnedTokens.css
@@ -16,6 +16,6 @@ a:hover {
 }
 
 
-.bscLink{
+.chainLink{
   color: grey;
 }

--- a/src/components/BurnedTokens.tsx
+++ b/src/components/BurnedTokens.tsx
@@ -156,10 +156,10 @@ const BurnedTokens = () => {
         Total burned: <b>{burnedTokensPercentage(numberOfBurnedTokens, numberOfBurnedTokensBSC)}%</b> 
       </li>
       <li>
-        Avalanche holders: <b>{numberWithCommas(numberOfTokenHolders)} (<a className="chainLink" href="https://cchain.explorer.avax.network/tokens/0x6e7f5C0b9f4432716bDd0a77a3601291b9D9e985/token-holders">AvaxExplorer</a>)</b>
+        Avalanche holders: <b>{numberWithCommas(numberOfTokenHolders)} (<a className="chainLink" href="https://cchain.explorer.avax.network/tokens/0x6e7f5C0b9f4432716bDd0a77a3601291b9D9e985/token-holders" target='_blank'>AvaxExplorer</a>)</b>
       </li>
       <li>
-        BSC holders: <b>{numberWithCommas(numberOfTokenHoldersBSC)}+ (<a className="chainLink" href="https://bscscan.com/token/0x33a3d962955a3862c8093d1273344719f03ca17c#balances">BscScan</a>)</b>
+        BSC holders: <b>{numberWithCommas(numberOfTokenHoldersBSC)}+ (<a className="chainLink" href="https://bscscan.com/token/0x33a3d962955a3862c8093d1273344719f03ca17c#balances" target='_blank'>BscScan</a>)</b>
       </li>
     </>
   );

--- a/src/components/BurnedTokens.tsx
+++ b/src/components/BurnedTokens.tsx
@@ -156,10 +156,10 @@ const BurnedTokens = () => {
         Total burned: <b>{burnedTokensPercentage(numberOfBurnedTokens, numberOfBurnedTokensBSC)}%</b> 
       </li>
       <li>
-        Avalanche holders: <b>{numberOfTokenHolders}</b>
+        Avalanche holders: <b>{numberWithCommas(numberOfTokenHolders)} (<a className="chainLink" href="https://cchain.explorer.avax.network/tokens/0x6e7f5C0b9f4432716bDd0a77a3601291b9D9e985/token-holders">AvaxExplorer</a>)</b>
       </li>
       <li>
-        BSC holders: <b>{numberOfTokenHoldersBSC}+. <a className="bscLink" href="https://bscscan.com/token/0x33a3d962955a3862c8093d1273344719f03ca17c">bscscan</a></b>
+        BSC holders: <b>{numberWithCommas(numberOfTokenHoldersBSC)}+ (<a className="chainLink" href="https://bscscan.com/token/0x33a3d962955a3862c8093d1273344719f03ca17c#balances">BscScan</a>)</b>
       </li>
     </>
   );


### PR DESCRIPTION
Update holder: Now use the numberWithCommas function for a better readability

Add links to holders: added links who directly point out to the holders on the blockchains

Links to holders: now open in a new tab so the spore.earth homepage does not get closed