### PR TITLE
1) Change anchor for Pangolin and set _target to "_blank" on Vote.tsx; 2)Multiples minor fixes (display) in the Marketplace 

### DIFF
--- a/src/components/NFT/MarketPlace.tsx
+++ b/src/components/NFT/MarketPlace.tsx
@@ -49,6 +49,10 @@ export const MarketPlaceView = (props: Props) => {
 
     })
 
+    const numberWithCommasNFT = (x: number) => {
+        return Math.ceil(x).toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,');
+    }
+
     return (
         <>
             {marketPlaceItems.length > 0 ? (
@@ -56,12 +60,15 @@ export const MarketPlaceView = (props: Props) => {
                     <div key={item.itemId}>
                         {/* <img className="rounded shadow" src={item[2].image} height="200" /> */}
                         <div className="col-md-3 text-center"><img className="rounded shadow" src={findimage(item.itemId)} alt="reload your page" height="200" /></div>
-                        <p>ID: {item.itemId}</p>
-                        <p>Price: {item.price} AVAX</p>
-
+                        <p>
+                            <div className="center-text-NFT"><b>ID: {item.itemId}</b></div>
+                            <div className="align-text-NFT">Price = {numberWithCommasNFT(item.price)} AVAX</div>
+                            
+                        </p>
+                        
                     </div>
                 ))) : (
-                <p> No NFTs for Sale </p>
+                <p> No NFTs for Sale!</p>
             )}
         </>
     )

--- a/src/components/NFT/NFT.css
+++ b/src/components/NFT/NFT.css
@@ -39,4 +39,12 @@
     display: flex;
   justify-content: center;
   }
-  
+
+.center-text-NFT {
+    text-align:center;
+}
+
+.align-text-NFT {
+    padding-left: 15px;
+    padding-bottom: 15px;
+}

--- a/src/components/NFT/NFT.tsx
+++ b/src/components/NFT/NFT.tsx
@@ -300,9 +300,11 @@ const NFT = (props: any) => {
                   className="form-control"
                 />
                 <div className="input-group-append">
-                  <button onClick={NFTbuy} className="btn btn-primary">Buy NFT</button>
+                    <button onClick={NFTbuy} className="btn btn-primary">Buy NFT</button>
                 </div>
-              </div>
+                </div>
+                <p className="text-muted">
+                    <b>*Note: </b>Displayed price is rounded up if not an integer (you may pay a little less than expected).</p>
             </div>
           </div>
         </div>

--- a/src/components/Vote.tsx
+++ b/src/components/Vote.tsx
@@ -102,7 +102,9 @@ const Vote = (props: any) => {
              <div className="mb-1 col-md-12 py-5">
              <div className="col-md-12 text-justify" >  
                 <p>
-                Help Spore increase liquidity by voting for us in the Pangolin proposal!  If you had $PNG in you wallet before {startdate.toUTCString()} you can vote directly on the Pangolin site  (<a className="link-color" href="https://app.pangolin.exchange/#/vote/5">link</a>). If you need help or have any questions, please ask in <a className="link-color" href="https://t.me/sporefinanceofficial">Telegram</a> or <a className="link-color" href="https://discord.gg/xRrArCTG9Q">Discord</a>.</p>
+                  Help Spore increase liquidity by voting for us in the Pangolin proposal! 
+                  If you had $PNG in you wallet before {startdate.toUTCString()} you can vote directly on the <a className="link-color" href="https://app.pangolin.exchange/#/vote/5" target='_blank' rel='noreferrer'>Pangolin site</a>.
+                  If you need help or have any questions, please ask in <a className="link-color" href="https://t.me/sporefinanceofficial" target='_blank' rel='noreferrer'>Telegram</a> or <a className="link-color" href="https://discord.gg/xRrArCTG9Q" target='_blank' rel='noreferrer'>Discord</a>.</p>
                   </div>
                   <div className="col-md-12 text-justify">
                   <p> <b>{numberWithCommas(forVotes)}</b> votes have been cast so far in favor of the proposal. Spore has already cast its delegated votes with Pangolin. Voting will continue until {enddate.toUTCString()}. </p>


### PR DESCRIPTION
1) Change anchor for Pangolin and set target to "_blank" on Vote.tsx:
- Change anchor for Pangolin: put link on "Pangolin site" for consistency with other links (e.g. Telegram)
- Change target on Vote.tsx: set it to "_blank" for consistency (in regards to other links) and so the page does not get closed when clicking links

2) Multiples minor fixes (display) in the Marketplace:
- Prices in AVAX is now rounded up if needed: no more padding and/or text overlaps if the price is set with a lot of digits. Buyer will always pay the displayed price or a little less.
- Added a Note that explains the previous point to the buyer: for clarity
- Prices in AVAX now follow the same rule than other numbers (comma separator): better consistency
- Center and bold ID: better readability
- Align prices with images: better readability